### PR TITLE
Use personal-files and switch to strict confinement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.snap
+prime/

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -5,17 +5,38 @@ description: |
  Services.
 version: git
 version-script: cat $SNAPCRAFT_STAGE/version
+base: core18
 
-confinement: classic
+confinement: strict
 grade: stable
+
+plugs:
+  personal-files:
+    read:
+      - $HOME/.aws
 
 apps:
   aws:
-    # Workaround https://bugs.launchpad.net/snappy/+bug/1664427
-    command: usr/bin/python3 $SNAP/bin/aws
+    adapter: full
+    command-chain:
+      - bin/launcher.sh
+    command: bin/aws
     completer: bin/aws_bash_completer
+    plugs:
+      - network
+      - network-bind
+      - personal-files
+      - home
 
 parts:
+  launcher:
+    plugin: dump
+    source: https://github.com/mikf/gallery-dl.git
+    source-depth: 1
+    organize:
+      snap/local/launchers/gallery-dl-launch: bin/launcher.sh
+    prime:
+      - bin/launcher.sh
   aws:
     plugin: python
     source: https://github.com/aws/aws-cli.git


### PR DESCRIPTION
* Use core18 base
* Use strict confinement with personal-files for $HOME/.aws
* Add launcher part to pull launcher script from gallery-dl to correctly determine the user's actual $HOME outside of snap confinement
* Plug network, network-bind and home for the aws app
* Specify adapter: full and use command-chain to avoid creating additional wrapper scripts

Note that you could probably copy the relevant snippet from launcher part and use that instead of copying it in, but I thought it was simplest to just copy it over. 