### PR TITLE
Issue 6 - update personal interface

### DIFF
--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -3,7 +3,6 @@ summary: Universal Command Line Interface for Amazon Web Services
 description: |
  This package provides a unified command line interface to Amazon Web
  Services.
-version: git
 base: core18
 adopt-info: aws
 confinement: strict

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -13,8 +13,6 @@ plugs:
     interface: personal-files
     write:
     - $HOME/.aws
-    read:
-    - $HOME/.aws
 apps:
   aws:
     adapter: full
@@ -27,7 +25,6 @@ apps:
       - network-bind
       - dot-aws
       - home
-
 parts:
   launcher:
     plugin: dump

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -10,10 +10,12 @@ confinement: strict
 grade: stable
 
 plugs:
-  personal-files:
-    write:
-      - $HOME/.aws
-
+  dot-aws:
+    interface: personal-files
+      write:
+        - $HOME/.aws
+      read:
+        - $HOME/.aws
 apps:
   aws:
     adapter: full

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -11,10 +11,10 @@ grade: stable
 plugs:
   dot-aws:
     interface: personal-files
-      write:
-      - $HOME/.aws
-      read:
-      - $HOME/.aws
+    write:
+    - $HOME/.aws
+    read:
+    - $HOME/.aws
 apps:
   aws:
     adapter: full

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -24,7 +24,7 @@ apps:
     plugs:
       - network
       - network-bind
-      - personal-files
+      - dot-aws
       - home
 
 parts:

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -12,9 +12,9 @@ plugs:
   dot-aws:
     interface: personal-files
       write:
-        - $HOME/.aws
+      - $HOME/.aws
       read:
-        - $HOME/.aws
+      - $HOME/.aws
 apps:
   aws:
     adapter: full


### PR DESCRIPTION
The personal interface was set for both read and write. According to Daniel from Canonical, this was caused by setting both read and write for the personal interface when only write was sufficient. 